### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hamekoz.yml
+++ b/.github/workflows/hamekoz.yml
@@ -1,4 +1,6 @@
 name: Hamekoz
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/hamekoz/Hamekoz.NET.Sdk/security/code-scanning/4](https://github.com/hamekoz/Hamekoz.NET.Sdk/security/code-scanning/4)

The best way to fix this problem is to add a `permissions` key at the root of the workflow file (`.github/workflows/hamekoz.yml`), specifying the minimum privileges needed. Since the jobs in this workflow only call reusable workflows and the permissions required to run those workflows are not clear from the snippet shown, the most restrictive safe default is:

```yaml
permissions:
  contents: read
```

This is the recommended starting point from GitHub's own documentation and can be relaxed if any workflow fails due to insufficient permissions. The new `permissions` block should be inserted after the `name` key (after line 1), ensuring it is at the workflow file's root and therefore applies to all jobs unless individually overridden.

No additional dependencies, imports, or code changes elsewhere are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
